### PR TITLE
Add Analytics clean up by date and Staging-safe Version History cleanup

### DIFF
--- a/src/KX11/KenticoClearVersionHistoryAndAttachmentHistory-STAGING-SAFE.v11.sql
+++ b/src/KX11/KenticoClearVersionHistoryAndAttachmentHistory-STAGING-SAFE.v11.sql
@@ -1,0 +1,41 @@
+/* KenticoClearVersionHistoryAndAttachmentHistory.v11.sql	*/
+/* Goal: Clean up data from Pages Tree			*/
+/* Description: Truncates version history except the most recent. or checked out */
+/* This is safer than totally clearing as if you push a page that has workflow */
+/* but the version history is gone, then the staging module will not push */
+/* Child objects, thus you could destroy any child relationships.  This prevents that. */
+/* Be very careful with this one, there is no coming back	*/
+/* Intended Kentico Verison: 11.x               */
+/* Author: Trevor Fayas (tfayas@gmail.com)    */
+/* Revision: 1.0                                */
+/* Take a backup first! Don't be THAT guy!      */
+
+-- Delets Version Attachment Binding which also deletes the attachment history
+delete from CMS_VersionAttachment where VersionHistoryID in (
+	select VH.VersionHistoryID from CMS_VersionHistory VH
+	left join CMS_Document D on D.DocumentID = VH.DocumentID
+	where 
+	-- Don't select the current or published version histories
+	D.DocumentCheckedOutVersionHistoryID <> VH.VersionHistoryID and
+	D.DocumentPublishedVersionHistoryID  <> VH.VersionHistoryID
+)
+
+-- Delete the Workflow History
+delete from CMS_WorkflowHistory where VersionHistoryID in (
+	select VH.VersionHistoryID from CMS_VersionHistory VH
+	left join CMS_Document D on D.DocumentID = VH.DocumentID
+	where 
+	-- Don't select the current or published version histories
+	D.DocumentCheckedOutVersionHistoryID <> VH.VersionHistoryID and
+	D.DocumentPublishedVersionHistoryID  <> VH.VersionHistoryID
+)
+
+-- Delete the version history
+delete from CMS_VersionHistory where VersionHistoryID in (
+	select VH.VersionHistoryID from CMS_VersionHistory VH
+	left join CMS_Document D on D.DocumentID = VH.DocumentID
+	where 
+	-- Don't select the current or published version histories
+	D.DocumentCheckedOutVersionHistoryID <> VH.VersionHistoryID and
+	D.DocumentPublishedVersionHistoryID  <> VH.VersionHistoryID
+)

--- a/src/KX11/KenticoDeleteAnalyticsData-ByDays.v11.sql
+++ b/src/KX11/KenticoDeleteAnalyticsData-ByDays.v11.sql
@@ -1,0 +1,38 @@
+  
+/* KenticoDeleteAnalyticsData-ByDays.v11.sql	*/
+/* Goal: Clean up analytics data beyond a given # of days		*/
+/* Description: Deletes individual Analytics Hits that are beyond the given */
+/* number of days.  This way you can delete data that is older than XXX days. */
+/* This can take a long time to run and isn't recommended you run while the site is */
+/* Being hit.  On one site with over 50 million records beyond the date it took 40 minutes to run. */
+/* Be very careful with this one, there is no coming back	*/
+/* Intended Kentico Verison: 11.x               */
+/* Author: Trevor Fayas (tfayas@gmail.com)    */
+/* Revision: 1.0                                */
+/* Take a backup first! Don't be THAT guy!      */
+
+
+declare @DaysToKeep int = 548; /* MODIFY ME */
+declare @CutOffDate datetime = null;
+
+-- Creates the cut off point
+set @CutOffDate = DATEADD(day, -1*@DaysToKeep, GETDATE())
+
+
+-- Delete various Analytics data that have an end time that is earlier than the cut off date.  
+-- DateDiff(day, '2020-01-15', '2020-01-01') would result in a negative number (Keep), 
+-- where as DateDiff(day, '2019-12-30', '2020-01-01') would result in a negative number and should be deleted
+delete from [Analytics_YearHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+   delete from [Analytics_MonthHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+  delete from [Analytics_WeekHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+   delete from [Analytics_DayHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+   delete from [Analytics_HourHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0

--- a/src/KX12/KenticoClearVersionHistoryAndAttachmentHistory-STAGING-SAFE.v11.sql
+++ b/src/KX12/KenticoClearVersionHistoryAndAttachmentHistory-STAGING-SAFE.v11.sql
@@ -1,0 +1,41 @@
+/* KenticoClearVersionHistoryAndAttachmentHistory.v11.sql	*/
+/* Goal: Clean up data from Pages Tree			*/
+/* Description: Truncates version history except the most recent. or checked out */
+/* This is safer than totally clearing as if you push a page that has workflow */
+/* but the version history is gone, then the staging module will not push */
+/* Child objects, thus you could destroy any child relationships.  This prevents that. */
+/* Be very careful with this one, there is no coming back	*/
+/* Intended Kentico Verison: 11.x               */
+/* Author: Trevor Fayas (tfayas@gmail.com)    */
+/* Revision: 1.0                                */
+/* Take a backup first! Don't be THAT guy!      */
+
+-- Delets Version Attachment Binding which also deletes the attachment history
+delete from CMS_VersionAttachment where VersionHistoryID in (
+	select VH.VersionHistoryID from CMS_VersionHistory VH
+	left join CMS_Document D on D.DocumentID = VH.DocumentID
+	where 
+	-- Don't select the current or published version histories
+	D.DocumentCheckedOutVersionHistoryID <> VH.VersionHistoryID and
+	D.DocumentPublishedVersionHistoryID  <> VH.VersionHistoryID
+)
+
+-- Delete the Workflow History
+delete from CMS_WorkflowHistory where VersionHistoryID in (
+	select VH.VersionHistoryID from CMS_VersionHistory VH
+	left join CMS_Document D on D.DocumentID = VH.DocumentID
+	where 
+	-- Don't select the current or published version histories
+	D.DocumentCheckedOutVersionHistoryID <> VH.VersionHistoryID and
+	D.DocumentPublishedVersionHistoryID  <> VH.VersionHistoryID
+)
+
+-- Delete the version history
+delete from CMS_VersionHistory where VersionHistoryID in (
+	select VH.VersionHistoryID from CMS_VersionHistory VH
+	left join CMS_Document D on D.DocumentID = VH.DocumentID
+	where 
+	-- Don't select the current or published version histories
+	D.DocumentCheckedOutVersionHistoryID <> VH.VersionHistoryID and
+	D.DocumentPublishedVersionHistoryID  <> VH.VersionHistoryID
+)

--- a/src/KX12/KenticoDeleteAnalyticsData-ByDays.v12.sql
+++ b/src/KX12/KenticoDeleteAnalyticsData-ByDays.v12.sql
@@ -1,0 +1,38 @@
+  
+/* KenticoDeleteAnalyticsData-ByDays.v12.sql	*/
+/* Goal: Clean up analytics data beyond a given # of days		*/
+/* Description: Deletes individual Analytics Hits that are beyond the given */
+/* number of days.  This way you can delete data that is older than XXX days. */
+/* This can take a long time to run and isn't recommended you run while the site is */
+/* Being hit.  On one site with over 50 million records beyond the date it took 40 minutes to run. */
+/* Be very careful with this one, there is no coming back	*/
+/* Intended Kentico Verison: 11.x               */
+/* Author: Trevor Fayas (tfayas@gmail.com)    */
+/* Revision: 1.0                                */
+/* Take a backup first! Don't be THAT guy!      */
+
+
+declare @DaysToKeep int = 548; /* MODIFY ME */
+declare @CutOffDate datetime = null;
+
+-- Creates the cut off point
+set @CutOffDate = DATEADD(day, -1*@DaysToKeep, GETDATE())
+
+
+-- Delete various Analytics data that have an end time that is earlier than the cut off date.  
+-- DateDiff(day, '2020-01-15', '2020-01-01') would result in a negative number (Keep), 
+-- where as DateDiff(day, '2019-12-30', '2020-01-01') would result in a negative number and should be deleted
+delete from [Analytics_YearHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+   delete from [Analytics_MonthHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+  delete from [Analytics_WeekHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+   delete from [Analytics_DayHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0
+
+   delete from [Analytics_HourHits]
+  where DATEDIFF(day, HitsEndTime, @CutOffDate) > 0


### PR DESCRIPTION
Truncating Version History causes an error in staging pages that are on workflow but have no version history, causing the CMS to push a page without child references, which will destroy child references on the target server when pushed.  This script removes all but the current Checked out history / published history.

Analytics clean up script to remove data older than XXX Days.